### PR TITLE
Fix Polybar Invocation/ Add launch script

### DIFF
--- a/.config/bspwm/bspwmrc
+++ b/.config/bspwm/bspwmrc
@@ -31,7 +31,7 @@ bspc config active_border_color         "#073642"
 #
 
 # Bar
-polybar top -c ~/.config/polybar/config.ini &
+~/.config/polybar/launch.sh &
 # Notifications
 /usr/bin/dunst &
 # Polkit

--- a/.config/polybar/launch.sh
+++ b/.config/polybar/launch.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+# Terminate already running bar instances
+killall -q polybar
+
+# Wait until the processes have been shut down
+while pgrep -u $UID -x polybar >/dev/null; do sleep 1; done
+
+# Launch Polybar
+polybar top -c ~/.config/polybar/config.ini &


### PR DESCRIPTION
Added a script to launch polybar. Old instance of polybar is killed before a new one is started. Ensures that whenever Bspwm restarts, the latest polybar config is used.