### PR TITLE
Fix Rofi Powermenu

### DIFF
--- a/.config/rofi/powermenu.sh
+++ b/.config/rofi/powermenu.sh
@@ -1,27 +1,27 @@
 #!/bin/env bash
 
 # Options for powermenu
-lock="  Lock"
-logout="  Logout"
-shutdown="  Shutdown"
-reboot="  Reboot"
-suspend="⏾  Sleep"
+lock="    Lock"
+logout="    Logout"
+shutdown="    Shutdown"
+reboot="    Reboot"
+sleep="   Sleep"
 
 # Get answer from user via rofi
 selected_option=$(echo "$lock
 $logout
-$shutdown
+$sleep
 $reboot
-$suspend" | rofi -dmenu\
-                 -i\
-                 -p "Power"\
-                 -config "~/.config/rofi/config.rasi"\
-                 -font "Symbols Nerd Font 12"\
-                 -width "15"\
-                 -lines 5\
-                 -line-margin 3\
-                 -line-padding 10\
-                 -scrollbar-width "0" )
+$shutdown" | rofi -dmenu\
+                  -i\
+                  -p "Power"\
+                  -config "~/.config/rofi/config.rasi"\
+                  -font "Symbols Nerd Font 12"\
+                  -width "15"\
+                  -lines 5\
+                  -line-margin 3\
+                  -line-padding 10\
+                  -scrollbar-width "0" )
 
 # Do something based on selected option
 if [ "$selected_option" == "$lock" ]
@@ -36,7 +36,7 @@ then
 elif [ "$selected_option" == "$reboot" ]
 then
     systemctl reboot
-elif [ "$selected_option" == "$suspend" ]
+elif [ "$selected_option" == "$sleep" ]
 then
     amixer set Master mute
     systemctl suspend

--- a/packages-repository.txt
+++ b/packages-repository.txt
@@ -48,3 +48,4 @@ capitaine-cursors
 galculator
 gtk-engine-murrine
 seahorse
+ttf-nerd-fonts-symbols


### PR DESCRIPTION
Changed one icon and added spacing to make Rofi Powermenu look more sane.
Added package `ttf-nerd-fonts-symbols`  for the icons to work.