### PR TITLE
Remove --hold argument

### DIFF
--- a/.config/polybar/config.ini
+++ b/.config/polybar/config.ini
@@ -546,7 +546,7 @@ margin-right = 0
 [module/keyhint]
 type = custom/text
 content = ""
-click-left = xfce4-terminal -e "less /home/$USER/.config/bspwm/keybindings" --hold
+click-left = xfce4-terminal -e "less /home/$USER/.config/bspwm/keybindings"
 content-foreground = ${colors.blue-darker}
 content-padding = 1
 margin-right = 0


### PR DESCRIPTION
This will close the shortcut window when we exist **"less"**

Current behavior :-
Exiting less using the '**q**' keybinding leaves a **xfce4-terminal** with no child process.

![image](https://user-images.githubusercontent.com/38587581/152577267-5d7d5754-b416-42d2-8cc5-f2959e52cb1a.png)
