### PR TITLE
swapped the icon for memory and cpu

### DIFF
--- a/.config/polybar/config.ini
+++ b/.config/polybar/config.ini
@@ -257,7 +257,7 @@ type = internal/cpu
 ; Default: 1
 interval = 0.5
 
-label = %{T1}%{T-}%{T2} %percentage:2%%%{T-}
+label = %{T1}%{T-}%{T2} %percentage:2%%%{T-}
 
 label-foreground = ${colors.cyan}
 
@@ -287,7 +287,7 @@ format = <label>
 ;   %gb_swap_free%
 ;   %gb_swap_used%
 
-label = %{T1}%{T-}%{T2} %gb_used%%{T-}
+label = %{T1}%{T-}%{T2} %gb_used%%{T-}
 
 label-foreground = ${colors.cyan}
 


### PR DESCRIPTION
The icons of both memory and CPU modules are not placed correctly

Before :-

![image](https://user-images.githubusercontent.com/38587581/154514374-ed9a50d4-bde8-43b0-90f7-ceb478a7fda1.png)

After :-

![image](https://user-images.githubusercontent.com/38587581/154514489-c8995abb-8931-4506-8c54-84afabc13923.png)


Don't know if its intended, kindly reject if that's the case.
