### PR TITLE
Fix picom autostart

### DIFF
--- a/.config/bspwm/bspwmrc
+++ b/.config/bspwm/bspwmrc
@@ -43,7 +43,7 @@ nitrogen --restore &
 # Dex
 dex -a -s /etc/xdg/autostart/:~/.config/autostart/  
 # Picom
-picom -b &
+# picom -b &
 # Network Applet
 nm-applet --indicator &
 

--- a/.config/bspwm/bspwmrc
+++ b/.config/bspwm/bspwmrc
@@ -43,7 +43,7 @@ nitrogen --restore &
 # Dex
 dex -a -s /etc/xdg/autostart/:~/.config/autostart/  
 # Picom
-# picom -CGb &
+picom -b &
 # Network Applet
 nm-applet --indicator &
 


### PR DESCRIPTION
Looks like picom was commented out by mistake, and therefore doesn't run on boot.

Also removed the flags ```C```, and ```G``` as they are deprecated.
 Shadows are already handled correctly in picom.conf