### PR TITLE
fixed broken links to pictures dir, made screenshot naming consistent…

### DIFF
--- a/.config/bspwm/scripts/screenshot.sh
+++ b/.config/bspwm/scripts/screenshot.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
 # options to be displayed
-option0="screen"
-option1="area"
-option2="window"
-
-# options to be displyed
+option0='screen'
+option1='select area or window'
+option2='currently focused window'
 options="$option0\n$option1\n$option2"
 
-selected="$(echo -e "$options" | rofi -lines 3 -dmenu -p "scrot")"
-case $selected in
-    $option0)
-        cd ~/$(xdg-user-dir PICTURES)/ && sleep 1 && scrot;;
-    $option1)
-        cd ~/$(xdg-user-dir PICTURES)/ && scrot -s;;
-    $option2)
-        cd ~/$(xdg-user-dir PICTURES)/ && sleep 1 && scrot -u;;
-esac
+# save file
+file="$(xdg-user-dir PICTURES)/screenshot-$(date +%F_%T).png"
 
+selected="$(echo -e "$options" | rofi -lines 3 -dmenu -p 'scrot')"
+case $selected in
+  "$option0")
+    sleep 1 && scrot -F "$file";;
+  "$option1")
+    sleep 1 && scrot -s -F "$file";;
+  "$option2")
+    sleep 1 && scrot -u -F "$file";;
+esac

--- a/.config/sxhkd/sxhkdrc
+++ b/.config/sxhkd/sxhkdrc
@@ -166,7 +166,7 @@ XF86MonBrightnessDown
 
 # Screenshot
 Print
-  scrot ~/$(xdg-user-dir PICTURES)/Screenshot-$(date +%F_%T).png
+  scrot "$(xdg-user-dir PICTURES)/screenshot-$(date +%F_%T).png"
 
 super + Print
   ~/.config/bspwm/scripts/screenshot.sh


### PR DESCRIPTION
… and changed scrot's option names passed to rofi to be more accurate to what they do. E.g. the resulting command for option1, `scrot -s`, can be used to select an area or a window by clicking on it.